### PR TITLE
Sync parent status to docs PR

### DIFF
--- a/src/plugins/DocsParenting/README.md
+++ b/src/plugins/DocsParenting/README.md
@@ -8,3 +8,7 @@ The goal fo this bot is to keep track if documentation PRs have related PRs. Thi
 
 - PRs against non-HA repo's, if there are up to 2 links to doc PRs in a new or updated PR description, we will add the `has-parent` label to the linked doc PRs.
 - If a doc PRs is opened or the description is updated, and the description links to PRs to non-doc repositories within the Home Assistant organization, add the `has-parent` label.
+- If a parent PR changes state to:
+  - `merged`: the docs PR will get label "parent-merged"
+  - `closed`: the docs PR will be closed
+  - `open`: make sure the docs PR is re-opened

--- a/src/plugins/DocsParenting/docs_parenting.ts
+++ b/src/plugins/DocsParenting/docs_parenting.ts
@@ -1,9 +1,6 @@
 import { PRContext } from "../../types";
 import { Application } from "probot";
-import {
-  extractRepoFromContext,
-  filterEventByRepo,
-} from "../../util/filter_event_repo";
+import { extractRepoFromContext } from "../../util/filter_event_repo";
 import { REPO_HOME_ASSISTANT_IO, ORG_HASS } from "../../const";
 import { getIssueFromPayload } from "../../util/issue";
 import { extractIssuesOrPullRequestLinksFromMarkdown } from "../../util/text_parser";
@@ -101,9 +98,6 @@ const runDocsParentingDocs = async (context: PRContext) => {
   });
 };
 
-const LABEL_PARENT_MERGED = "parent-merged";
-const LABEL_PARENT_CLOSED = "parent-closed";
-
 /**
  * Goal is to reflect the parent status on the docs PR.
  *  - parent opened: make sure docs PR is open
@@ -111,6 +105,9 @@ const LABEL_PARENT_CLOSED = "parent-closed";
  *  - parent merged: add label "parent-merged"
  */
 const updateDocsParentStatus = async (context: PRContext) => {
+  if (extractRepoFromContext(context) === REPO_HOME_ASSISTANT_IO) {
+    return;
+  }
   const log = (msg: string) => context.log(NAME, "PARENT-STATUS-SYNC", msg);
 
   const pr = context.payload.pull_request;

--- a/src/plugins/DocsParenting/docs_parenting.ts
+++ b/src/plugins/DocsParenting/docs_parenting.ts
@@ -17,7 +17,7 @@ export const initDocsParenting = (app: Application) => {
     }
   });
   app.on(
-    ["pull_request.opened", "pull_request.closed"],
+    ["pull_request.reopened", "pull_request.closed"],
     updateDocsParentStatus
   );
 };

--- a/src/plugins/DocsParenting/docs_parenting.ts
+++ b/src/plugins/DocsParenting/docs_parenting.ts
@@ -1,9 +1,13 @@
 import { PRContext } from "../../types";
 import { Application } from "probot";
-import { extractRepoFromContext } from "../../util/filter_event_repo";
+import {
+  extractRepoFromContext,
+  filterEventByRepo,
+} from "../../util/filter_event_repo";
 import { REPO_HOME_ASSISTANT_IO, ORG_HASS } from "../../const";
 import { getIssueFromPayload } from "../../util/issue";
-import { extractIssuesOrPullRequestLinksFromMarkdown } from "../../util/pull_request";
+import { extractIssuesOrPullRequestLinksFromMarkdown } from "../../util/text_parser";
+import { getPRState } from "../../util/pull_request";
 
 const NAME = "DocsParenting";
 
@@ -15,6 +19,10 @@ export const initDocsParenting = (app: Application) => {
       await runDocsParentingNonDocs(context);
     }
   });
+  app.on(
+    ["pull_request.opened", "pull_request.closed"],
+    updateDocsParentStatus
+  );
 };
 
 // Deal with PRs on Home Assistant Python repo
@@ -23,7 +31,7 @@ const runDocsParentingNonDocs = async (context: PRContext) => {
 
   const linksToDocs = extractIssuesOrPullRequestLinksFromMarkdown(
     triggerIssue.body
-  ).filter((link) => link.repository === REPO_HOME_ASSISTANT_IO);
+  ).filter((link) => link.repo === REPO_HOME_ASSISTANT_IO);
 
   context.log(
     NAME,
@@ -37,12 +45,16 @@ const runDocsParentingNonDocs = async (context: PRContext) => {
 
   if (linksToDocs.length > 2) {
     context.log(
+      NAME,
+      "NON-DOC-PR",
       "Not adding has-parent label because HASS PR has more than 2 links to docs PRs."
     );
     return;
   }
 
   context.log(
+    NAME,
+    "NON-DOC-PR",
     `Adding has-parent label to doc PRS ${linksToDocs
       .map((link) => link.number)
       .join(", ")}`
@@ -64,9 +76,7 @@ const runDocsParentingDocs = async (context: PRContext) => {
   const linksToNonDocs = extractIssuesOrPullRequestLinksFromMarkdown(
     triggerIssue.body
   ).filter(
-    (link) =>
-      link.organization === ORG_HASS &&
-      link.repository !== REPO_HOME_ASSISTANT_IO
+    (link) => link.owner === ORG_HASS && link.repo !== REPO_HOME_ASSISTANT_IO
   );
 
   context.log(
@@ -79,10 +89,88 @@ const runDocsParentingDocs = async (context: PRContext) => {
     return;
   }
 
-  context.log(`Adding has-parent label to doc PR ${triggerIssue.number}`);
+  context.log(
+    NAME,
+    "DOC-PR",
+    `Adding has-parent label to doc PR ${triggerIssue.number}`
+  );
 
   await context.github.issues.addLabels({
     ...context.issue(),
     labels: ["has-parent"],
+  });
+};
+
+const LABEL_PARENT_MERGED = "parent-merged";
+const LABEL_PARENT_CLOSED = "parent-closed";
+
+/**
+ * Goal is to reflect the parent status on the docs PR.
+ *  - parent opened: make sure docs PR is open
+ *  - parent closed: make sure docs PR is closed
+ *  - parent merged: add label "parent-merged"
+ */
+const updateDocsParentStatus = async (context: PRContext) => {
+  const log = (msg: string) => context.log(NAME, "PARENT-STATUS-SYNC", msg);
+
+  const pr = context.payload.pull_request;
+
+  const linksToDocs = extractIssuesOrPullRequestLinksFromMarkdown(
+    pr.body
+  ).filter((link) => link.repo === REPO_HOME_ASSISTANT_IO);
+
+  log(`PR ${pr.number} contains ${linksToDocs.length} links to doc PRs`);
+
+  if (linksToDocs.length !== 1) {
+    if (linksToDocs.length > 1) {
+      log(`Not doing work because more than 1 link found.`);
+    }
+    return;
+  }
+
+  const docLink = linksToDocs[0];
+  const parentState = getPRState(pr);
+
+  if (parentState === "open") {
+    // Parent is open, docs issue should be open too.
+    const docsPR = await docLink.fetchPR(context.github);
+    const docsPRState = getPRState(docsPR);
+
+    if (docsPRState === "open") {
+      log(
+        `Parent got opened, docs PR ${docLink.number} is already open. Not doing work`
+      );
+      return;
+    }
+
+    if (docsPRState === "merged") {
+      log(`Parent got opened but docs PR ${docLink.number} is already merged.`);
+      return;
+    }
+
+    // docs PR state == closed
+    log(`Parent got opened, opening docs PR ${docLink.number}.`);
+    await context.github.pulls.update({
+      ...docLink.pull(),
+      state: "open",
+    });
+    return;
+  }
+
+  if (parentState === "closed") {
+    log(`Parent got closed, closing docs PR ${docLink.number}`);
+    await context.github.pulls.update({
+      ...docLink.pull(),
+      state: "closed",
+    });
+    return;
+  }
+
+  // Parent state == merged
+  log(`Adding parent-merged label to doc PR ${docLink.number}`);
+
+  await context.github.issues.addLabels({
+    ...docLink.issue(),
+    labels: ["parent-merged"],
   });
 };

--- a/src/util/issue.ts
+++ b/src/util/issue.ts
@@ -1,10 +1,40 @@
 import { IssuesGetResponse } from "@octokit/rest";
-import { Context } from "probot";
 import { PRContext, IssueContext } from "../types";
 import {
   WebhookPayloadIssuesIssue,
   WebhookPayloadPullRequestPullRequest,
 } from "@octokit/webhooks";
+import { GitHubAPI } from "probot/lib/github";
+
+interface GitHubAPIpatched extends GitHubAPI {
+  _hassIssuesCache?: { [key: string]: Promise<IssuesGetResponse> };
+}
+
+export const fetchIssueWithCache = async (
+  github: GitHubAPI,
+  owner: string,
+  repo: string,
+  number: number
+) => {
+  const patchedContext = github as GitHubAPIpatched;
+  const key = `${owner}/${repo}/${number}`;
+
+  if (!patchedContext._hassIssuesCache) {
+    patchedContext._hassIssuesCache = {};
+  }
+
+  if (!(key in patchedContext._hassIssuesCache)) {
+    patchedContext._hassIssuesCache[key] = github.issues
+      .get({
+        owner,
+        repo,
+        issue_number: number,
+      })
+      .then(({ data }) => data);
+  }
+
+  return patchedContext._hassIssuesCache[key];
+};
 
 // PRs are shaped as issues. This method will help normalize it.
 export const getIssueFromPayload = (

--- a/src/util/text_parser.ts
+++ b/src/util/text_parser.ts
@@ -1,0 +1,78 @@
+import { GitHubAPI } from "probot/lib/github";
+import { fetchIssueWithCache } from "./issue";
+import { fetchPRWithCache } from "./pull_request";
+
+export class ParsedGitHubIssueOrPR {
+  public owner: string;
+  public repo: string;
+  public number: number;
+
+  constructor(owner: string, repo: string, number: number) {
+    this.owner = owner;
+    this.repo = repo;
+    this.number = number;
+  }
+
+  issue() {
+    return {
+      owner: this.owner,
+      repo: this.repo,
+      issue_number: this.number,
+    };
+  }
+
+  pull() {
+    return {
+      owner: this.owner,
+      repo: this.repo,
+      pull_number: this.number,
+    };
+  }
+
+  async fetchIssue(github: GitHubAPI) {
+    return await fetchIssueWithCache(
+      github,
+      this.owner,
+      this.repo,
+      this.number
+    );
+  }
+
+  async fetchPR(github: GitHubAPI) {
+    return await fetchPRWithCache(github, this.owner, this.repo, this.number);
+  }
+}
+
+export const extractIssuesOrPullRequestLinksFromHTML = (body: string) => {
+  const re = /https:\/\/github.com\/([\w-\.]+)\/([\w-\.]+)\/pull\/(\d+)/g;
+  let match;
+  const results: ParsedGitHubIssueOrPR[] = [];
+
+  do {
+    match = re.exec(body);
+    if (match) {
+      results.push(
+        new ParsedGitHubIssueOrPR(match[1], match[2], Number(match[3]))
+      );
+    }
+  } while (match);
+
+  return results;
+};
+
+export const extractIssuesOrPullRequestLinksFromMarkdown = (body: string) => {
+  const re = /([\w-\.]+)\/([\w-\.]+)#(\d+)/g;
+  let match;
+  const results: ParsedGitHubIssueOrPR[] = [];
+
+  do {
+    match = re.exec(body);
+    if (match) {
+      results.push(
+        new ParsedGitHubIssueOrPR(match[1], match[2], Number(match[3]))
+      );
+    }
+  } while (match);
+
+  return results;
+};

--- a/test/util/text_parser.spec.ts
+++ b/test/util/text_parser.spec.ts
@@ -3,23 +3,22 @@ import {
   ParsedGitHubIssueOrPR,
   extractIssuesOrPullRequestLinksFromHTML,
   extractIssuesOrPullRequestLinksFromMarkdown,
-} from "../../src/util/pull_request";
-import { GitHubAPI } from "probot/lib/github";
+} from "../../src/util/text_parser";
 
 describe("ParsedGitHubIssueOrPR", () => {
   it("parses pull request link", () => {
     const result = new ParsedGitHubIssueOrPR(
       "home-assistant",
       "home-assistant.io",
-      "10120"
+      10120
     );
-    assert.equal(result.organization, "home-assistant");
-    assert.equal(result.repository, "home-assistant.io");
-    assert.equal(result.number, "10120");
+    assert.equal(result.owner, "home-assistant");
+    assert.equal(result.repo, "home-assistant.io");
+    assert.equal(result.number, 10120);
   });
 });
 
-describe("extractPullRequestLinks", () => {
+describe("extractPullRequestLinksFromHTML", () => {
   it("finds pull request links", () => {
     const result = extractIssuesOrPullRequestLinksFromHTML(
       `
@@ -34,18 +33,18 @@ https://github.com/home-assistant/home-assistant-polymer/pull/512
     assert.equal(result.length, 2);
 
     const linkDocs = result[0];
-    assert.equal(linkDocs.organization, "home-assistant");
-    assert.equal(linkDocs.repository, "home-assistant.io");
-    assert.equal(linkDocs.number, "10120");
+    assert.equal(linkDocs.owner, "home-assistant");
+    assert.equal(linkDocs.repo, "home-assistant.io");
+    assert.equal(linkDocs.number, 10120);
 
     const linkPolymer = result[1];
-    assert.equal(linkPolymer.organization, "home-assistant");
-    assert.equal(linkPolymer.repository, "home-assistant-polymer");
-    assert.equal(linkPolymer.number, "512");
+    assert.equal(linkPolymer.owner, "home-assistant");
+    assert.equal(linkPolymer.repo, "home-assistant-polymer");
+    assert.equal(linkPolymer.number, 512);
   });
 });
 
-describe("extractPullRequestLinks", () => {
+describe("extractPullRequestLinksFromMarkdown", () => {
   it("finds pull request links", () => {
     const result = extractIssuesOrPullRequestLinksFromMarkdown(
       `
@@ -58,8 +57,8 @@ describe("extractPullRequestLinks", () => {
     assert.equal(result.length, 1);
 
     const linkDocs = result[0];
-    assert.equal(linkDocs.organization, "home-assistant");
-    assert.equal(linkDocs.repository, "home-assistant.io");
-    assert.equal(linkDocs.number, "10052");
+    assert.equal(linkDocs.owner, "home-assistant");
+    assert.equal(linkDocs.repo, "home-assistant.io");
+    assert.equal(linkDocs.number, 10052);
   });
 });


### PR DESCRIPTION
When a parent PR is closed, merged or re-opened, sync the status to the docs PR.

Fixes #10
Fixes #5