### PR TITLE
Add docs missing commit status

### DIFF
--- a/src/plugins/DocsMissing/README.md
+++ b/src/plugins/DocsMissing/README.md
@@ -1,0 +1,7 @@
+# Docs Missing
+
+Repository: `home-assistant`
+
+Maintain a commit status on a PR based on if the label "docs-missing" is present or not.
+
+Will be used in Home Assistant that we do not merge PRs before docs are added.

--- a/src/plugins/DocsMissing/docs_missing.ts
+++ b/src/plugins/DocsMissing/docs_missing.ts
@@ -1,0 +1,33 @@
+import { PRContext } from "../../types";
+import { Application } from "probot";
+import { REPO_HOME_ASSISTANT } from "../../const";
+import { filterEventByRepo } from "../../util/filter_event_repo";
+import { WebhookPayloadIssuesIssue } from "@octokit/webhooks";
+
+const NAME = "DocsMissing";
+
+export const initDocsMissing = (app: Application) => {
+  app.on(
+    "pull_request.labeled",
+    filterEventByRepo(NAME, REPO_HOME_ASSISTANT, runDocsMissing)
+  );
+};
+
+export const runDocsMissing = async (context: PRContext) => {
+  const pr = context.payload.pull_request;
+
+  const hasDocsMissingLabel = (pr.labels as WebhookPayloadIssuesIssue["labels"])
+    .map((label) => label.name)
+    .includes("docs-missing");
+
+  await context.github.repos.createStatus(
+    context.repo({
+      sha: pr.head.sha,
+      context: "docs-missing",
+      state: hasDocsMissingLabel ? "failure" : "success",
+      description: hasDocsMissingLabel
+        ? `Please open a documentation PR.`
+        : `Documentation ok.`,
+    })
+  );
+};

--- a/src/probot_app.ts
+++ b/src/probot_app.ts
@@ -5,6 +5,7 @@ import { initReviewEnforcer } from "./plugins/ReviewEnforcer/review_enforcer";
 import { initDocsParenting } from "./plugins/DocsParenting/docs_parenting";
 import { initLabelCleaner } from "./plugins/LabelCleaner/label_cleaner";
 import { initDocsBranchLabels } from "./plugins/DocsBranchLabels/docs_branch_labels";
+import { initDocsMissing } from "./plugins/DocsMissing/docs_missing";
 
 export const probotApp = (app: Application) => {
   initLabelBot(app);
@@ -13,4 +14,5 @@ export const probotApp = (app: Application) => {
   initDocsParenting(app);
   initLabelCleaner(app);
   initDocsBranchLabels(app);
+  initDocsMissing(app);
 };


### PR DESCRIPTION
Fixes #14

Requires us to make `docs-missing` an approved commit check on Home Assistant repo. 

<img width="324" alt="image" src="https://user-images.githubusercontent.com/1444314/62968840-c5b73700-bdc0-11e9-98b8-9d8663e0b866.png">
