### PR TITLE
✏️ Change to correct label name

### DIFF
--- a/src/plugins/LabelCleaner/label_cleaner.ts
+++ b/src/plugins/LabelCleaner/label_cleaner.ts
@@ -13,7 +13,7 @@ const TO_CLEAN: { [key: string]: string[] } = {
   [REPO_HOME_ASSISTANT_IO]: [
     "needs-rebase",
     "in-progress",
-    "awaiting-parent",
+    "awaits-parent",
     "ready-for-review",
     "parent-merged",
   ],


### PR DESCRIPTION
I noticed that the `awaits-parent` label was not removed after a merge, this PR will solve that.