### PR TITLE
Improve integration labeling of PRs

### DIFF
--- a/src/plugins/LabelBot/strategies/componentAndPlatform.ts
+++ b/src/plugins/LabelBot/strategies/componentAndPlatform.ts
@@ -1,9 +1,7 @@
 import { PRContext } from "../../../types";
 import { ParsedPath } from "../../../util/parse_path";
 
-const VALID_TYPES = ["component", "platform"];
-
 export default (context: PRContext, parsed: ParsedPath[]) =>
   parsed
-    .filter((file) => VALID_TYPES.includes(file.type))
+    .filter((file) => file.component)
     .map((file) => `integration: ${file.component}`);

--- a/test/plugins/LabelBot/strategies/componentAndPlatform.spec.ts
+++ b/test/plugins/LabelBot/strategies/componentAndPlatform.spec.ts
@@ -4,11 +4,11 @@ import comp from "../../../../src/plugins/LabelBot/strategies/componentAndPlatfo
 
 import { ParsedPath } from "../../../../src/util/parse_path";
 
-function getOutput(file) {
+function getOutput(file, prefix = "homeassistant/components/") {
   var output = comp(null, [
     new ParsedPath(
       // @ts-ignore
-      { filename: "homeassistant/components/" + file }
+      { filename: prefix + file }
     ),
   ]);
   return output.length ? output[0] : null;
@@ -40,7 +40,7 @@ describe("componentAndPlatform", () => {
   });
 
   it("component services", () => {
-    assert.deepEqual(getOutput("light/services.yaml"), null);
+    assert.deepEqual(getOutput("light/services.yaml"), "integration: light");
   });
 
   it("generic services", () => {
@@ -49,5 +49,12 @@ describe("componentAndPlatform", () => {
 
   it("component init file", () => {
     assert.deepEqual(getOutput("cover/__init__.py"), "integration: cover");
+  });
+
+  it("component tests", () => {
+    assert.deepEqual(
+      getOutput("linky/conftest.py", "tests/components/"),
+      "integration: linky"
+    );
   });
 });


### PR DESCRIPTION
My PR https://github.com/home-assistant/home-assistant/pull/31299 didn't get labeled with the correct integration. I had to do it _manually_ 😱. This PR should avoid this in the future.