### PR TITLE
Update review enforcer

### DIFF
--- a/src/plugins/ReviewEnforcer/review_enforcer.ts
+++ b/src/plugins/ReviewEnforcer/review_enforcer.ts
@@ -18,7 +18,7 @@ const USERS = [
   "snicker",
 ];
 
-const INTEGRATIONS = ["konnected"];
+const INTEGRATIONS = ["konnected", "xiaomi_miio"];
 
 export const initReviewEnforcer = (app: Application) => {
   app.on("pull_request.opened", filterEventNoBot(NAME, runReviewEnforcer));
@@ -67,12 +67,9 @@ const checkPythonPRFiles = async (context: PRContext) => {
 
 const markForReview = async (context: PRContext) => {
   await Promise.all([
-    context.github.issues.addAssignees(
-      context.issue({ assignees: ["balloob"] })
-    ),
     context.github.issues.createComment(
       context.issue({
-        body: `This pull request needs to be manually signed off by @balloob before it can get merged.`,
+        body: `This pull request needs to be manually signed off by @home-assistant/core before it can get merged.`,
       })
     ),
   ]);

--- a/src/plugins/ReviewEnforcer/review_enforcer.ts
+++ b/src/plugins/ReviewEnforcer/review_enforcer.ts
@@ -13,12 +13,9 @@ import { ParsedDocsPath } from "../../util/parse_docs_path";
 const NAME = "ReviewEnforcer";
 
 const USERS = [
-  // Konnected.io, tried to merge an affiliate integration to monetize HA
-  "heythisisnate",
-  "snicker",
 ];
 
-const INTEGRATIONS = ["konnected", "xiaomi_miio"];
+const INTEGRATIONS = ["xiaomi_miio"];
 
 export const initReviewEnforcer = (app: Application) => {
   app.on("pull_request.opened", filterEventNoBot(NAME, runReviewEnforcer));
@@ -66,11 +63,9 @@ const checkPythonPRFiles = async (context: PRContext) => {
 };
 
 const markForReview = async (context: PRContext) => {
-  await Promise.all([
-    context.github.issues.createComment(
-      context.issue({
-        body: `This pull request needs to be manually signed off by @home-assistant/core before it can get merged.`,
-      })
-    ),
-  ]);
+  await context.github.issues.createComment(
+    context.issue({
+      body: `This pull request needs to be manually signed off by @home-assistant/core before it can get merged.`,
+    })
+  );
 };


### PR DESCRIPTION
I haven't tested this.

- Add xiaomi_miio to require a review by core team. The integration doesn't follow our design guidelines and we need to make sure it doesn't get worse.
- Remove PR assignment.
- Require review by core team instead of balloob. I think it's enough if one of us reviews in these cases.