### PR TITLE
Install packages when creating devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
   "name": "Probot Home Assistant",
   "context": "..",
   "dockerFile": "Dockerfile",
+  "postCreateCommand": "yarn install",
   "extensions": [
     "visualstudioexptteam.vscodeintellicode",
     "esbenp.prettier-vscode"


### PR DESCRIPTION
This runs `yarn install` when creating the devcotainer so everything is ready when it starts.