### PR TITLE
Extract tasks

### DIFF
--- a/src/plugins/LabelBot/strategies/typeOfChange.ts
+++ b/src/plugins/LabelBot/strategies/typeOfChange.ts
@@ -1,38 +1,50 @@
 import { PRContext } from "../../../types";
 import { ParsedPath } from "../../../util/parse_path";
+import { extractTasks } from "../../../util/text_parser";
 
 const BODYMATCHES = [
   {
-    key: /\\n- \[(x|X)\] Bugfix /,
-    label: "type: bugfix",
+    description: "Bugfix (non-breaking change which fixes an issue)",
+    labels: ["type: bugfix"],
   },
   {
-    key: /\\n- \[(x|X)\] Dependency upgrade/,
-    label: "type: dependency",
+    description: "Dependency upgrade",
+    labels: ["type: dependency"],
   },
   {
-    key: /\\n- \[(x|X)\] New integration /,
-    label: "type: new-integration",
+    description: "New integration (thank you!)",
+    labels: ["type: new-integration"],
   },
   {
-    key: /\\n- \[(x|X)\] New feature /,
-    label: "type: new-feature",
+    description:
+      "New feature (which adds functionality to an existing integration)",
+    labels: ["type: new-feature"],
   },
   {
-    key: /\\n- \[(x|X)\] Breaking change /,
-    label: "type: breaking-change",
+    description:
+      "Breaking change (fix/feature causing existing functionality to break)",
+    labels: ["type: breaking-change"],
   },
   {
-    key: /\\n- \[(x|X)\] Code quality improvements /,
-    label: "type: code-quality",
+    description:
+      "Code quality improvements to existing code or addition of tests",
+    labels: ["type: code-quality"],
   },
 ];
 
 export default function(context: PRContext, parsed: ParsedPath[]) {
+  const completedTasks = extractTasks(context.payload.pull_request.body || "")
+    .filter((task) => {
+      return task.checked;
+    })
+    .map((task) => task.description);
+
   let labels: string[] = [];
   BODYMATCHES.forEach((match) => {
-    if (match.key.test(context.payload.pull_request.body)) {
-      labels.push(match.label);
+    if (completedTasks.includes(match.description)) {
+      match.labels.forEach((label) => {
+        labels.push(label);
+      });
     }
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,3 +10,8 @@ export type PRContext = Context<WebhookPayloadPullRequest>;
 export type IssueContext = Context<WebhookPayloadIssues>;
 export type LabeledIssueOrPRContext = (PRContext | IssueContext) &
   Context<WebhookPayloadLabel>;
+
+export interface PullOrBodyTask {
+  checked: boolean;
+  description: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,8 +10,3 @@ export type PRContext = Context<WebhookPayloadPullRequest>;
 export type IssueContext = Context<WebhookPayloadIssues>;
 export type LabeledIssueOrPRContext = (PRContext | IssueContext) &
   Context<WebhookPayloadLabel>;
-
-export interface PullOrBodyTask {
-  checked: boolean;
-  description: string;
-}

--- a/src/util/text_parser.ts
+++ b/src/util/text_parser.ts
@@ -1,7 +1,11 @@
 import { GitHubAPI } from "probot/lib/github";
 import { fetchIssueWithCache } from "./issue";
 import { fetchPRWithCache } from "./pull_request";
-import { PullOrBodyTask } from "../types";
+
+interface PullOrBodyTask {
+  checked: boolean;
+  description: string;
+}
 
 export class ParsedGitHubIssueOrPR {
   public owner: string;

--- a/src/util/text_parser.ts
+++ b/src/util/text_parser.ts
@@ -92,10 +92,10 @@ export const extractTasks = (body: string) => {
       return;
     }
 
+    const lineSplit = line.split(matchAll);
     const checked: boolean = matchChecked.test(line);
-    const description: string = line
-      .split(matchAll)
-      [line.split(matchAll).length - 1].trim()
+    const description: string = lineSplit[lineSplit.length - 1]
+      .trim()
       .replace(/\\r/g, "");
     tasks.push({ checked, description });
   });

--- a/src/util/text_parser.ts
+++ b/src/util/text_parser.ts
@@ -88,16 +88,12 @@ export const extractTasks = (body: string) => {
   let tasks: PullOrBodyTask[] = [];
 
   body.split("\n").forEach((line: string) => {
-    let checked: boolean = false;
-    let description: string;
     if (!line.trim().startsWith("- [")) {
       return;
     }
 
-    if (matchChecked.test(line)) {
-      checked = true;
-    }
-    description = line
+    const checked: boolean = matchChecked.test(line);
+    const description: string = line
       .split(matchAll)
       [line.split(matchAll).length - 1].trim()
       .replace(/\\r/g, "");

--- a/src/util/text_parser.ts
+++ b/src/util/text_parser.ts
@@ -1,6 +1,7 @@
 import { GitHubAPI } from "probot/lib/github";
 import { fetchIssueWithCache } from "./issue";
 import { fetchPRWithCache } from "./pull_request";
+import { PullOrBodyTask } from "../types";
 
 export class ParsedGitHubIssueOrPR {
   public owner: string;
@@ -75,4 +76,28 @@ export const extractIssuesOrPullRequestMarkdownLinks = (body: string) => {
   } while (match);
 
   return results;
+};
+
+export const extractTasks = (body: string) => {
+  const matchAll = /- \[( |)(x|X| |)(| )\] /;
+  const matchChecked = /- \[( |)(x|X)(| )\] /;
+  let tasks: PullOrBodyTask[] = [];
+
+  body.split("\n").forEach((line: string) => {
+    let checked: boolean = false;
+    let description: string;
+    if (!line.trim().startsWith("- [")) {
+      return;
+    }
+
+    if (matchChecked.test(line)) {
+      checked = true;
+    }
+    description = line
+      .split(matchAll)
+      [line.split(matchAll).length - 1].trim()
+      .replace(/\\r/g, "");
+    tasks.push({ checked, description });
+  });
+  return tasks;
 };

--- a/test/plugins/LabelBot/strategies/typeOfChange.spec.ts
+++ b/test/plugins/LabelBot/strategies/typeOfChange.spec.ts
@@ -15,7 +15,7 @@ describe("LabelBotPlugin - typeOfChange", () => {
           base: {
             ref: "master",
           },
-          body: "\\n- [X] Dependency upgrade",
+          body: "\n- [X] Dependency upgrade",
         },
       },
       // @ts-ignore
@@ -47,7 +47,7 @@ describe("LabelBotPlugin - typeOfChange", () => {
           base: {
             ref: "master",
           },
-          body: "\\n- [X] Bugfix (non-breakin change)",
+          body: "\n- [X] Bugfix (non-breaking change which fixes an issue)",
         },
       },
       // @ts-ignore
@@ -79,7 +79,7 @@ describe("LabelBotPlugin - typeOfChange", () => {
           base: {
             ref: "master",
           },
-          body: "\\n- [X] New integration (thank you!)",
+          body: "\n- [X] New integration (thank you!)",
         },
       },
       // @ts-ignore
@@ -112,7 +112,7 @@ describe("LabelBotPlugin - typeOfChange", () => {
             ref: "master",
           },
           body:
-            "\\n- [X] New feature (which adds functionality to an existing integration)",
+            "\n- [X] New feature (which adds functionality to an existing integration)",
         },
       },
       // @ts-ignore
@@ -145,7 +145,7 @@ describe("LabelBotPlugin - typeOfChange", () => {
             ref: "master",
           },
           body:
-            "\\n- [X] Breaking change (fix/feature causing existing functionality to break)",
+            "\n- [X] Breaking change (fix/feature causing existing functionality to break)",
         },
       },
       // @ts-ignore
@@ -178,7 +178,7 @@ describe("LabelBotPlugin - typeOfChange", () => {
             ref: "master",
           },
           body:
-            "\\n- [X] Code quality improvements to existing code or addition of tests",
+            "\n- [X] Code quality improvements to existing code or addition of tests",
         },
       },
       // @ts-ignore


### PR DESCRIPTION
The implementation introduced in #42 was flawed.

- This PR adds a new `extractTasks` feature, this is more robust than the initial implementation, and it can be used by other strategies as well.

- The `typeOfChange` strategy has been adjusted to use `extractTasks`