### PR TITLE
Strip type prefix from tasks

### DIFF
--- a/src/plugins/LabelBot/strategies/typeOfChange.ts
+++ b/src/plugins/LabelBot/strategies/typeOfChange.ts
@@ -5,30 +5,30 @@ import { extractTasks } from "../../../util/text_parser";
 const BODYMATCHES = [
   {
     description: "Bugfix (non-breaking change which fixes an issue)",
-    labels: ["type: bugfix"],
+    labels: ["bugfix"],
   },
   {
     description: "Dependency upgrade",
-    labels: ["type: dependency"],
+    labels: ["dependency"],
   },
   {
     description: "New integration (thank you!)",
-    labels: ["type: new-integration"],
+    labels: ["new-integration"],
   },
   {
     description:
       "New feature (which adds functionality to an existing integration)",
-    labels: ["type: new-feature"],
+    labels: ["new-feature"],
   },
   {
     description:
       "Breaking change (fix/feature causing existing functionality to break)",
-    labels: ["type: breaking-change"],
+    labels: ["breaking-change"],
   },
   {
     description:
       "Code quality improvements to existing code or addition of tests",
-    labels: ["type: code-quality"],
+    labels: ["code-quality"],
   },
 ];
 

--- a/test/plugins/LabelBot/strategies/typeOfChange.spec.ts
+++ b/test/plugins/LabelBot/strategies/typeOfChange.spec.ts
@@ -31,7 +31,7 @@ describe("LabelBotPlugin - typeOfChange", () => {
       _prFiles: [],
     });
     assert.deepEqual(setLabels, {
-      labels: ["merging-to-master", "small-pr", "type: dependency"],
+      labels: ["merging-to-master", "small-pr", "dependency"],
     });
   });
   it("bugfix", async () => {
@@ -63,7 +63,7 @@ describe("LabelBotPlugin - typeOfChange", () => {
       _prFiles: [],
     });
     assert.deepEqual(setLabels, {
-      labels: ["merging-to-master", "small-pr", "type: bugfix"],
+      labels: ["merging-to-master", "small-pr", "bugfix"],
     });
   });
   it("New integration", async () => {
@@ -95,7 +95,7 @@ describe("LabelBotPlugin - typeOfChange", () => {
       _prFiles: [],
     });
     assert.deepEqual(setLabels, {
-      labels: ["merging-to-master", "small-pr", "type: new-integration"],
+      labels: ["merging-to-master", "small-pr", "new-integration"],
     });
   });
   it("New feature", async () => {
@@ -128,7 +128,7 @@ describe("LabelBotPlugin - typeOfChange", () => {
       _prFiles: [],
     });
     assert.deepEqual(setLabels, {
-      labels: ["merging-to-master", "small-pr", "type: new-feature"],
+      labels: ["merging-to-master", "small-pr", "new-feature"],
     });
   });
   it("Breaking change", async () => {
@@ -161,7 +161,7 @@ describe("LabelBotPlugin - typeOfChange", () => {
       _prFiles: [],
     });
     assert.deepEqual(setLabels, {
-      labels: ["merging-to-master", "small-pr", "type: breaking-change"],
+      labels: ["merging-to-master", "small-pr", "breaking-change"],
     });
   });
   it("Code quality", async () => {
@@ -194,7 +194,7 @@ describe("LabelBotPlugin - typeOfChange", () => {
       _prFiles: [],
     });
     assert.deepEqual(setLabels, {
-      labels: ["merging-to-master", "small-pr", "type: code-quality"],
+      labels: ["merging-to-master", "small-pr", "code-quality"],
     });
   });
 });


### PR DESCRIPTION
Strips the `type: ` prefix from new issues, so that we no longer have two breaking change labels. 

Just before releasing this, we should rename the old labels and merge the breaking change ones.