### PR TITLE
Schedule comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@types/debounce": "^1.2.0",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.6.8",
     "husky": "^3.0.1",
@@ -27,6 +28,7 @@
   "dependencies": {
     "@probot/serverless-lambda": "^0.3.0",
     "codeowners-utils": "^1.0.0",
+    "debounce": "^1.2.0",
     "ignore": "^5.1.2",
     "probot": "^9.2.19"
   },

--- a/src/plugins/CodeOwnersMention/code_owners_mention.ts
+++ b/src/plugins/CodeOwnersMention/code_owners_mention.ts
@@ -3,8 +3,8 @@ import { LabeledIssueOrPRContext } from "../../types";
 import { Application } from "probot";
 import { REPO_CORE } from "../../const";
 import { filterEventByRepo } from "../../util/filter_event_repo";
-import { filterEventNoBot } from "../../util/filter_event_no_bot";
 import { getIssueFromPayload } from "../../util/issue";
+import { scheduleComment } from "../../util/comment";
 import { WebhookPayloadIssuesIssue } from "@octokit/webhooks";
 
 const NAME = "CodeOwnersMention";
@@ -97,9 +97,7 @@ export const runCodeOwnersMention = async (
       `Adding comment to ${triggerLabel} ${triggerURL}: ${commentBody}`
     );
 
-    promises.push(
-      context.github.issues.createComment(context.issue({ body: commentBody }))
-    );
+    scheduleComment(context, "CodeOwnersMention", commentBody);
   }
 
   // Add a label if author of issue/PR is a code owner

--- a/src/plugins/DocsTargetBranch/docs_target_branch.ts
+++ b/src/plugins/DocsTargetBranch/docs_target_branch.ts
@@ -14,6 +14,7 @@ import {
   extractPullRequestURLLinks,
 } from "../../util/text_parser";
 import { getIssueFromPayload } from "../../util/issue";
+import { scheduleComment } from "../../util/comment";
 
 const NAME = "DocsTargetBranch";
 const SKIP_REPOS = [REPO_BRANDS, REPO_DEV_DOCUMENTATION];
@@ -100,13 +101,7 @@ const wrongTargetBranchDetected = async (
     `Adding comment to ${context.payload.pull_request.number}: ${body}`
   );
 
-  promises.push(
-    context.github.issues.createComment(
-      context.issue({
-        body,
-      })
-    )
-  );
+  scheduleComment(context, "DocsTargetBranch", body);
 
   await Promise.all(promises);
 };

--- a/src/plugins/ReviewEnforcer/review_enforcer.ts
+++ b/src/plugins/ReviewEnforcer/review_enforcer.ts
@@ -9,13 +9,15 @@ import { filterEventNoBot } from "../../util/filter_event_no_bot";
 import { fetchPullRequestFilesFromContext } from "../../util/pull_request";
 import { ParsedPath } from "../../util/parse_path";
 import { ParsedDocsPath } from "../../util/parse_docs_path";
+import { scheduleComment } from "../../util/comment";
 
 const NAME = "ReviewEnforcer";
 
-const USERS = [
-];
+const USERS = [];
 
 const INTEGRATIONS = ["xiaomi_miio"];
+
+const commentBody = `This pull request needs to be manually signed off by @home-assistant/core before it can get merged.`;
 
 export const initReviewEnforcer = (app: Application) => {
   app.on("pull_request.opened", filterEventNoBot(NAME, runReviewEnforcer));
@@ -63,9 +65,5 @@ const checkPythonPRFiles = async (context: PRContext) => {
 };
 
 const markForReview = async (context: PRContext) => {
-  await context.github.issues.createComment(
-    context.issue({
-      body: `This pull request needs to be manually signed off by @home-assistant/core before it can get merged.`,
-    })
-  );
+  scheduleComment(context, "ReviewEnforcer", commentBody);
 };

--- a/src/util/comment.ts
+++ b/src/util/comment.ts
@@ -1,0 +1,49 @@
+/**
+ * Helper to leave a comment on a PR.
+ *
+ * We debounce it so that we only leave 1 comment with all notices.
+ */
+import { debounce } from "debounce";
+import { PRContext, IssueContext } from "../types";
+
+type PatchedContext = (PRContext | IssueContext) & {
+  _commentsToPost?: Array<{ handler: string; message: string }>;
+};
+
+const WAIT_COMMENTS = 200; // ms
+
+const postComment = (context: PRContext | IssueContext) => {
+  const patchedContext = context as PatchedContext;
+  const comments = patchedContext._commentsToPost!;
+
+  // Can happen if race condition etc.
+  if (comments.length === 0) {
+    return;
+  }
+
+  // Empty it, in case probot takes longer than 300ms and this runs again.
+  patchedContext._commentsToPost = [];
+
+  const toPost = comments.map((comment) => {
+    `${comment.message} <sub><sup>(message by ${comment.handler})</sup></sub>`;
+  });
+
+  let commentBody = toPost.join("\n\n---\n\n");
+
+  context.github.issues.createComment(context.issue({ body: commentBody }));
+};
+
+const debouncedPostComment = debounce(postComment, WAIT_COMMENTS);
+
+export const scheduleComment = (
+  context: PRContext | IssueContext,
+  handler: string,
+  message: string
+) => {
+  const patchedContext = context as PatchedContext;
+  if (!("_commentsToPost" in patchedContext)) {
+    patchedContext._commentsToPost = [];
+  }
+  patchedContext._commentsToPost.push({ handler, message });
+  debouncedPostComment(context);
+};

--- a/test/plugins/DocsTargetBranch/docs_target_branch.spec.ts
+++ b/test/plugins/DocsTargetBranch/docs_target_branch.spec.ts
@@ -4,6 +4,7 @@ import {
   bodyShouldTargetCurrent,
   bodyShouldTargetNext,
 } from "../../../src/plugins/DocsTargetBranch/docs_target_branch";
+import { PRContext } from "../../../src/types";
 
 describe("DocsTargetBranch", () => {
   it("The branch is correct (current)", async () => {
@@ -100,9 +101,8 @@ describe("DocsTargetBranch", () => {
   it("Is next, should be current", async () => {
     let setLabels: any;
     let setAssignees: any;
-    let creteMessageBody: any;
 
-    await runDocsTargetBranch({
+    const context: Partial<PRContext> = {
       // @ts-ignore
       log: () => undefined,
       name: "pull_request",
@@ -132,30 +132,28 @@ describe("DocsTargetBranch", () => {
           async addAssignees(assignees) {
             setAssignees = assignees;
           },
-          // @ts-ignore
-          async createComment(body) {
-            creteMessageBody = body;
-          },
         },
       },
       _prFiles: [],
-    });
+    };
+    await runDocsTargetBranch(context as any);
     assert.deepEqual(setLabels, {
       labels: ["needs-rebase", "in-progress"],
     });
     assert.deepEqual(setAssignees, {
       assignees: ["developer"],
     });
-    assert.deepEqual(creteMessageBody, {
-      body: bodyShouldTargetCurrent,
-    });
+    assert.deepEqual(
+      (context as any)._commentsToPost[0].message,
+      bodyShouldTargetCurrent
+    );
   });
   it("Is current, should be next", async () => {
     let setLabels: any;
     let setAssignees: any;
-    let creteMessageBody: any;
+    let createMessageBody: any;
 
-    await runDocsTargetBranch({
+    const context: Partial<PRContext> = {
       // @ts-ignore
       log: () => undefined,
       name: "pull_request",
@@ -188,21 +186,23 @@ describe("DocsTargetBranch", () => {
           },
           // @ts-ignore
           async createComment(body) {
-            creteMessageBody = body;
+            createMessageBody = body;
           },
         },
       },
       _prFiles: [],
-    });
+    };
+    await runDocsTargetBranch(context as any);
     assert.deepEqual(setLabels, {
       labels: ["needs-rebase", "in-progress"],
     });
     assert.deepEqual(setAssignees, {
       assignees: ["developer"],
     });
-    assert.deepEqual(creteMessageBody, {
-      body: bodyShouldTargetNext,
-    });
+    assert.deepEqual(
+      (context as any)._commentsToPost[0].message,
+      bodyShouldTargetNext
+    );
   });
   it("Label 'needs-rebase' already exsist", async () => {
     await runDocsTargetBranch({

--- a/yarn.lock
+++ b/yarn.lock
@@ -225,6 +225,11 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@types/debounce@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/debounce/-/debounce-1.2.0.tgz#9ee99259f41018c640b3929e1bb32c3dcecdb192"
+  integrity sha512-bWG5wapaWgbss9E238T0R6bfo5Fh3OkeoSt245CM7JJwVwpw6MEBCbIxLq5z8KzsE3uJhzcIuQkyiZmzV3M/Dw==
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -1098,6 +1103,11 @@ date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
+
+debounce@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
+  integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
 
 debug@2.6.9, debug@^2.2.0:
   version "2.6.9"


### PR DESCRIPTION
Add a utility function to schedule comments so that we only post a single comment instead of spamming the PR with multiple. Note that this only debounces it within a single execution of probot. So if a PR gets two labels added, that's two different executions posting comments.

This can help with #49 and also with some other ideas I have had. 