### PR TITLE
Force lowercase for codeowner check

### DIFF
--- a/src/plugins/CodeOwnersMention/code_owners_mention.ts
+++ b/src/plugins/CodeOwnersMention/code_owners_mention.ts
@@ -52,7 +52,7 @@ export const runCodeOwnersMention = async (
 
   const owners = match.owners.map(
     // Remove the `@`
-    (usr) => usr.substring(1)
+    (usr) => usr.substring(1).toLowerCase()
   );
 
   const codeownersLine = `${codeownersData.data.html_url}#L${match.line}`;
@@ -69,7 +69,7 @@ export const runCodeOwnersMention = async (
     commenter.user.login.toLowerCase()
   );
 
-  const payloadUsername = triggerIssue.user.login;
+  const payloadUsername = triggerIssue.user.login.toLowerCase();
   const ownersMinusAuthor = owners.filter((usr) => usr !== payloadUsername);
 
   const promises: Promise<unknown>[] = [


### PR DESCRIPTION
"by-code-owner" is not added if the username is not an exact match in the CODEOWNERS file.
<https://github.com/home-assistant/core/pull/35366>
<https://github.com/home-assistant/core/blob/4663845ebcb6f84d73db2109096eaa4ae56ed186/CODEOWNERS#L420>

This forces lowercase so those situations also get a label.