### PR TITLE
Don't add component labels if too many of them

### DIFF
--- a/src/plugins/LabelBot/label_bot.ts
+++ b/src/plugins/LabelBot/label_bot.ts
@@ -20,7 +20,6 @@ import { REPO_CORE } from "../../const";
 const NAME = "LabelBot";
 
 const STRATEGIES = [
-  componentAndPlatform,
   newIntegrationOrPlatform,
   removePlatform,
   warnOnMergeToMaster,
@@ -52,6 +51,16 @@ export const runLabelBot = async (context: PRContext) => {
       labelSet.add(label);
     }
   });
+
+  // componentAndPlatform can create many labels, process them separately
+  const componentLabelSet = new Set();
+  for (let label of componentAndPlatform(context, parsed)) {
+    componentLabelSet.add(label);
+  }
+
+  if (labelSet.size + componentLabelSet.size <= 9) {
+    componentLabelSet.forEach(labelSet.add, labelSet);
+  }
 
   const labels = Array.from(labelSet);
 

--- a/test/plugins/LabelBot/label_bot.spec.ts
+++ b/test/plugins/LabelBot/label_bot.spec.ts
@@ -33,7 +33,72 @@ describe("LabelBotPlugin", () => {
       ],
     });
     assert.deepEqual(setLabels, {
-      labels: ["integration: mqtt", "merging-to-master", "core"],
+      labels: ["merging-to-master", "core", "integration: mqtt"],
+    });
+  });
+
+  it("many labels", async () => {
+    let setLabels: any;
+
+    await runLabelBot({
+      // @ts-ignore
+      log: () => undefined,
+      payload: {
+        pull_request: {
+          // @ts-ignore
+          base: {
+            ref: "master",
+          },
+          body:
+            "\n- [x] Bugfix (non-breaking change which fixes an issue)" +
+            "\n- [x] Breaking change (fix/feature causing existing functionality to break)",
+        },
+      },
+      // @ts-ignore
+      issue: (val) => val,
+      github: {
+        issues: {
+          // @ts-ignore
+          async addLabels(labels) {
+            setLabels = labels;
+          },
+        },
+      },
+      _prFiles: [
+        {
+          filename: "homeassistant/components/mqtt/climate.py",
+        },
+        {
+          filename: "homeassistant/components/hue/light.py",
+        },
+        {
+          filename: "homeassistant/components/zha/lock.py",
+        },
+        {
+          filename: "homeassistant/components/switch/group.py",
+        },
+        {
+          filename: "homeassistant/components/camera/__init__.py",
+        },
+        {
+          filename: "homeassistant/components/zwave/sensor.py",
+        },
+        {
+          filename: "homeassistant/components/zeroconf/usage.py",
+        },
+        {
+          filename: "homeassistant/components/xiaomi/device_tracker.py",
+        },
+        {
+          filename: "homeassistant/components/tts/notify.py",
+        },
+        {
+          filename: "homeassistant/components/serial/sensor.py",
+        },
+      ],
+    });
+    assert.deepEqual(setLabels, {
+      labels: ["merging-to-master", "core", "bugfix", "breaking-change"],
     });
   });
 });


### PR DESCRIPTION
I noticed when you touch many components during refactoring, no labels are added.

I think it's better to drop `integration: *` labels but still add others.

All other strategies add 1 or 2 fixed labels and although in extreme case they can still overflow above 9, that should be very rare.

Added test to cover such case.