### PR TITLE
Fix dropped comments when debouncing different contexts

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -4,6 +4,8 @@ export const REPO_CORE = "core";
 export const REPO_DEV_DOCUMENTATION = "developers.home-assistant";
 export const REPO_HOME_ASSISTANT_IO = "home-assistant.io";
 
+export const COMMENT_DEBOUNCE_TIME = 500;
+
 export const entityComponents = [
   "air_quality",
   "alarm_control_panel",

--- a/src/util/comment.ts
+++ b/src/util/comment.ts
@@ -4,6 +4,7 @@
  * We debounce it so that we only leave 1 comment with all notices.
  */
 import { debounce } from "debounce";
+import { COMMENT_DEBOUNCE_TIME } from "../const";
 import { PRContext, IssueContext } from "../types";
 import { getIssueFromPayload } from "./issue";
 
@@ -12,8 +13,6 @@ type PendingComment = {
   context: PRContext | IssueContext,
   comments: Array<{ handler: string, message: string }>;
 }
-
-const WAIT_COMMENTS = 500; // ms
 
 const pendingComments = new Map<string, PendingComment>();
 
@@ -41,7 +40,7 @@ export const scheduleComment = (
   const key = getIssueFromPayload(context).url;
   if (!pendingComments.has(key)) {
     pendingComments.set(key, {
-      debouncedPost: debounce(() => postComment(key), WAIT_COMMENTS),
+      debouncedPost: debounce(() => postComment(key), COMMENT_DEBOUNCE_TIME),
       context,
       comments: []
     });

--- a/test/plugins/DocsTargetBranch/docs_target_branch.spec.ts
+++ b/test/plugins/DocsTargetBranch/docs_target_branch.spec.ts
@@ -5,6 +5,7 @@ import {
   bodyShouldTargetNext,
 } from "../../../src/plugins/DocsTargetBranch/docs_target_branch";
 import { PRContext } from "../../../src/types";
+import { COMMENT_DEBOUNCE_TIME } from "../../../src/const";
 
 const sleep = (duration) => new Promise(resolve => setTimeout(resolve, duration));
 
@@ -147,7 +148,7 @@ describe("DocsTargetBranch", () => {
       _prFiles: [],
     };
     await runDocsTargetBranch(context as any);
-    await sleep(1000); // wait for comment debouncing
+    await sleep(COMMENT_DEBOUNCE_TIME + 50); // wait for comment debouncing to run
     assert.deepEqual(setLabels, {
       labels: ["needs-rebase", "in-progress"],
     });
@@ -202,7 +203,7 @@ describe("DocsTargetBranch", () => {
       _prFiles: [],
     };
     await runDocsTargetBranch(context as any);
-    await sleep(1000); // wait for comment debouncing
+    await sleep(COMMENT_DEBOUNCE_TIME + 50); // wait for comment debouncing to run
     assert.deepEqual(setLabels, {
       labels: ["needs-rebase", "in-progress"],
     });

--- a/test/plugins/IssueLinks/issue_links.spec.ts
+++ b/test/plugins/IssueLinks/issue_links.spec.ts
@@ -6,9 +6,12 @@ describe("IssueLinks", () => {
     await runIssueLinks({
       // @ts-ignore
       log: () => undefined,
+      name: "issues",
       payload: {
         // @ts-ignore
         label: { name: "integration: awesome" },
+        // @ts-ignore
+        issue: { url: "https://api.github.com/repos/home-assistant/core/issues/1234" }
       },
       // @ts-ignore
       issue: (val) => val,


### PR DESCRIPTION
I noticed on the ESPHome repository that for pull requests labeled with multiple integrations, only a single codeowner got mentioned, even though all codeowners got assigned. 

This is caused by the debouncing in the `scheduleComment` function. When multiple labels are applied, GitHub delivers one webhook for every applied label to probot, and probot thus runs the `CodeOwnersMention` plugin multiple times. Crucially, this happens with different contexts. The old `scheduleComment` function saved the pending comments to the context and then ran the `postComment` function debounced. However, since the debouncing applies to the function and not the function + argument pair, the `postComment` function was only invoked for the last context. Any messages saved to the other contexts were thus lost.

I think #79 might also be caused by this.

For obvious reasons I haven't been able to test this running against the Home Assistant GitHub, but as far as I can test it locally and on my own repositories it works.
