### PR TITLE
Await posting of comments & group messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "@probot/serverless-lambda": "^0.3.0",
     "codeowners-utils": "^1.0.0",
-    "debounce": "^1.2.0",
     "ignore": "^5.1.2",
     "probot": "^9.2.19"
   },

--- a/src/plugins/CodeOwnersMention/code_owners_mention.ts
+++ b/src/plugins/CodeOwnersMention/code_owners_mention.ts
@@ -109,7 +109,7 @@ export const runCodeOwnersMention = async (
       `Adding comment to ${triggerLabel} ${triggerURL}: ${commentBody}`
     );
 
-    scheduleComment(context, "CodeOwnersMention", commentBody);
+    promises.push(scheduleComment(context, "CodeOwnersMention", commentBody));
   }
 
   // Add a label if author of issue/PR is a code owner

--- a/src/plugins/DocsTargetBranch/docs_target_branch.ts
+++ b/src/plugins/DocsTargetBranch/docs_target_branch.ts
@@ -139,7 +139,7 @@ const wrongTargetBranchDetected = async (
     `Adding comment to ${context.payload.pull_request.number}: ${body}`
   );
 
-  scheduleComment(context, "DocsTargetBranch", body);
+  promises.push(scheduleComment(context, "DocsTargetBranch", body));
 
   await Promise.all(promises);
 };

--- a/src/plugins/IssueLinks/issue_links.ts
+++ b/src/plugins/IssueLinks/issue_links.ts
@@ -24,5 +24,5 @@ export const runIssueLinks = async (context: LabeledIssueOrPRContext) => {
   const commentBody = `[${integrationName} documentation](${docLink})\n[${integrationName} source](${codeLink})`;
 
   context.log(NAME, `Adding comment with links ${commentBody}`);
-  scheduleComment(context, "IssueLinks", commentBody);
+  await scheduleComment(context, "IssueLinks", commentBody);
 };

--- a/src/plugins/ReviewEnforcer/review_enforcer.ts
+++ b/src/plugins/ReviewEnforcer/review_enforcer.ts
@@ -65,5 +65,5 @@ const checkPythonPRFiles = async (context: PRContext) => {
 };
 
 const markForReview = async (context: PRContext) => {
-  scheduleComment(context, "ReviewEnforcer", commentBody);
+  await scheduleComment(context, "ReviewEnforcer", commentBody);
 };

--- a/src/util/comment.ts
+++ b/src/util/comment.ts
@@ -22,12 +22,17 @@ const postComment = (key: string) => {
 
   const context = pendingComment.context;
 
-  const toPost = pendingComment.comments.map(
-    (comment) =>
-      `${comment.message}\n<sub><sup>(message by ${comment.handler})</sup></sub>`
+  // Group messages by handler in alphabetical order
+  const handlers = new Set(pendingComment.comments.map((c) => c.handler));
+  const toPost = [...handlers].sort().map(
+    (handler) =>
+      `${pendingComment.comments
+        .filter((comment) => comment.handler === handler)
+        .map((comment) => comment.message)
+        .join("\n")}\n` + `<sub><sup>(message by ${handler})</sup></sub>`
   );
 
-  let commentBody = toPost.join("\n\n---\n\n");
+  const commentBody = toPost.join("\n\n---\n\n");
 
   context.github.issues.createComment(context.issue({ body: commentBody }));
 };

--- a/src/util/comment.ts
+++ b/src/util/comment.ts
@@ -3,10 +3,10 @@
  *
  * We debounce it so that we only leave 1 comment with all notices.
  */
-import { debounce } from "debounce";
 import { COMMENT_DEBOUNCE_TIME } from "../const";
 import { PRContext, IssueContext } from "../types";
 import { getIssueFromPayload } from "./issue";
+import { debounce } from "./debounce";
 
 type PendingComment = {
   debouncedPost: Function,
@@ -16,7 +16,7 @@ type PendingComment = {
 
 const pendingComments = new Map<string, PendingComment>();
 
-const postComment = (key: string) => {
+const postComment = async (key: string) => {
   const pendingComment = pendingComments.get(key);
   pendingComments.delete(key);
 
@@ -34,10 +34,10 @@ const postComment = (key: string) => {
 
   const commentBody = toPost.join("\n\n---\n\n");
 
-  context.github.issues.createComment(context.issue({ body: commentBody }));
+  await context.github.issues.createComment(context.issue({ body: commentBody }));
 };
 
-export const scheduleComment = (
+export const scheduleComment = async (
   context: PRContext | IssueContext,
   handler: string,
   message: string
@@ -53,5 +53,5 @@ export const scheduleComment = (
 
   const pendingComment = pendingComments.get(key);
   pendingComment.comments.push({ handler, message });
-  pendingComment.debouncedPost();
+  await pendingComment.debouncedPost();
 };

--- a/src/util/comment.ts
+++ b/src/util/comment.ts
@@ -9,10 +9,10 @@ import { getIssueFromPayload } from "./issue";
 import { debounce } from "./debounce";
 
 type PendingComment = {
-  debouncedPost: Function,
-  context: PRContext | IssueContext,
-  comments: Array<{ handler: string, message: string }>;
-}
+  debouncedPost: Function;
+  context: PRContext | IssueContext;
+  comments: Array<{ handler: string; message: string }>;
+};
 
 const pendingComments = new Map<string, PendingComment>();
 
@@ -34,7 +34,9 @@ const postComment = async (key: string) => {
 
   const commentBody = toPost.join("\n\n---\n\n");
 
-  await context.github.issues.createComment(context.issue({ body: commentBody }));
+  await context.github.issues.createComment(
+    context.issue({ body: commentBody })
+  );
 };
 
 export const scheduleComment = async (
@@ -47,7 +49,7 @@ export const scheduleComment = async (
     pendingComments.set(key, {
       debouncedPost: debounce(() => postComment(key), COMMENT_DEBOUNCE_TIME),
       context,
-      comments: []
+      comments: [],
     });
   }
 

--- a/src/util/debounce.ts
+++ b/src/util/debounce.ts
@@ -1,0 +1,31 @@
+/**
+ * Helper to debounce a function. Returns a promise that can be awaited to wait
+ * until the function has ran, and get the return value.
+ */
+export const debounce = <T>(
+  func: () => T,
+  wait: number
+): (() => Promise<T>) => {
+  let timeout: NodeJS.Timeout = null;
+  let resolve: (T) => void = null;
+  let reject: (T) => void = null;
+  let promise: Promise<T> = null;
+
+  return () => {
+    if (promise == null)
+      promise = new Promise<T>((res, rej) => ([resolve, reject] = [res, rej]));
+
+    const later = () => {
+      timeout = promise = null;
+      try {
+        resolve(func());
+      } catch (e) {
+        reject(e);
+      }
+    };
+
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+    return promise;
+  };
+};

--- a/test/plugins/DocsTargetBranch/docs_target_branch.spec.ts
+++ b/test/plugins/DocsTargetBranch/docs_target_branch.spec.ts
@@ -148,7 +148,6 @@ describe("DocsTargetBranch", () => {
       _prFiles: [],
     };
     await runDocsTargetBranch(context as any);
-    await sleep(COMMENT_DEBOUNCE_TIME + 50); // wait for comment debouncing to run
     assert.deepEqual(setLabels, {
       labels: ["needs-rebase", "in-progress"],
     });
@@ -203,7 +202,6 @@ describe("DocsTargetBranch", () => {
       _prFiles: [],
     };
     await runDocsTargetBranch(context as any);
-    await sleep(COMMENT_DEBOUNCE_TIME + 50); // wait for comment debouncing to run
     assert.deepEqual(setLabels, {
       labels: ["needs-rebase", "in-progress"],
     });

--- a/test/plugins/IssueLinks/issue_links.spec.ts
+++ b/test/plugins/IssueLinks/issue_links.spec.ts
@@ -3,6 +3,8 @@ import { runIssueLinks } from "../../../src/plugins/IssueLinks/issue_links";
 
 describe("IssueLinks", () => {
   it("Add comment", async () => {
+    let createComment: any;
+
     await runIssueLinks({
       // @ts-ignore
       log: () => undefined,
@@ -17,9 +19,15 @@ describe("IssueLinks", () => {
       issue: (val) => val,
       github: {
         // @ts-ignore
-        issues: {},
+        issues: {
+          // @ts-ignore
+          async createComment(body) {
+            createComment = body;
+          },
+        }
       },
       _prFiles: [],
     });
+    assert.ok(createComment.body.indexOf("awesome documentation") !== -1);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1146,11 +1146,6 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-debounce@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
-  integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
-
 debug@2.6.9, debug@^2.2.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
As a follow-up to #80, I realized that posting the comments wasn't actually awaited. This isn't necessarily an issue (it wasn't before #80 either), but if something goes wrong while posting the comment, the error isn't caught. Possibly it also causes [this](https://github.com/home-assistant/probot-home-assistant/issues/79#issuecomment-877980349) problem.

Furthermore, the comments generated could get very long if multiple integrations were labeled on an issue:

> [abc documentation](https://www.home-assistant.io/integrations/abc)
> [abc source](https://github.com/home-assistant/core/tree/dev/homeassistant/components/abc)
> <sub><sup>(message by IssueLinks)</sup></sub>
>
> ---
>
> [def documentation](https://www.home-assistant.io/integrations/def)
> [def source](https://github.com/home-assistant/core/tree/dev/homeassistant/components/def)
> <sub><sup>(message by IssueLinks)</sup></sub>
>
> ---
>
> Hey there @oxan, mind taking a look at this feedback as it has been labeled with an integration (abc) you are listed as a [code owner](https://github.com/home-assistant/core/blob/dev/CODEOWNERS#L1) for? Thanks!
> <sub><sup>(message by CodeOwnersMention)</sup></sub>
>
> ---
>
> Hey there @oxan, mind taking a look at this feedback as it has been labeled with an integration (def) you are listed as a [code owner](https://github.com/home-assistant/core/blob/dev/CODEOWNERS#L2) for? Thanks!
> <sub><sup>(message by CodeOwnersMention)</sup></sub>

I added grouping of the messages by handler:

> Hey there @oxan, mind taking a look at this feedback as it has been labeled with an integration (`abc`) you are listed as a [code owner](https://github.com/home-assistant/core/blob/dev/CODEOWNERS#L1) for? Thanks!
> Hey there @oxan, mind taking a look at this feedback as it has been labeled with an integration (`def`) you are listed as a [code owner](https://github.com/home-assistant/core/blob/dev/CODEOWNERS#L2) for? Thanks!
> <sub><sup>(message by CodeOwnersMention)</sup></sub>
>
> ---
> 
> [abc documentation](https://www.home-assistant.io/integrations/abc)
> [abc source](https://github.com/home-assistant/core/tree/dev/homeassistant/components/abc)
> [def documentation](https://www.home-assistant.io/integrations/def)
> [def source](https://github.com/home-assistant/core/tree/dev/homeassistant/components/def)
> <sub><sup>(message by IssueLinks)</sup></sub>

If wanted, it could be further abbreviated by putting the documentation & source links for each integration on a single line. Merging the messages for multiple integrations is complicated though. 