### PR TITLE
Add promiseWrapper

### DIFF
--- a/src/util/promiseWrapper.ts
+++ b/src/util/promiseWrapper.ts
@@ -1,0 +1,14 @@
+// Wrapper to guard against exceptions
+
+import { LoggerWithTarget } from "probot/lib/wrap-logger";
+
+export const promiseWrapper = async (
+  logger: LoggerWithTarget,
+  promise: Promise<unknown>
+): Promise<void> => {
+  try {
+    await promise;
+  } catch (err) {
+    logger(err);
+  }
+};


### PR DESCRIPTION
Add `promiseWrapper` to catch and log the error instead of reaching an unhandled exception.

Useful in cases where we collect multiple promises and execute with `Promise.all`