### PR TITLE
Add support for labeling deprecations

### DIFF
--- a/src/plugins/LabelBot/strategies/typeOfChange.ts
+++ b/src/plugins/LabelBot/strategies/typeOfChange.ts
@@ -22,6 +22,11 @@ const BODYMATCHES = [
   },
   {
     description:
+      "Deprecation (breaking change to happen in the future)",
+    labels: ["deprecation"],
+  },
+  {
+    description:
       "Breaking change (fix/feature causing existing functionality to break)",
     labels: ["breaking-change"],
   },

--- a/test/plugins/LabelBot/strategies/typeOfChange.spec.ts
+++ b/test/plugins/LabelBot/strategies/typeOfChange.spec.ts
@@ -131,6 +131,39 @@ describe("LabelBotPlugin - typeOfChange", () => {
       labels: ["merging-to-master", "small-pr", "new-feature"],
     });
   });
+  it("Deprecation", async () => {
+    let setLabels: any;
+
+    await runLabelBot({
+      // @ts-ignore
+      log: () => undefined,
+      payload: {
+        // @ts-ignore
+        pull_request: {
+          // @ts-ignore
+          base: {
+            ref: "master",
+          },
+          body:
+            "\n- [x] Deprecation (breaking change to happen in the future)",
+        },
+      },
+      // @ts-ignore
+      issue: (val) => val,
+      github: {
+        issues: {
+          // @ts-ignore
+          async addLabels(labels) {
+            setLabels = labels;
+          },
+        },
+      },
+      _prFiles: [],
+    });
+    assert.deepEqual(setLabels, {
+      labels: ["merging-to-master", "small-pr", "deprecation"],
+    });
+  });
   it("Breaking change", async () => {
     let setLabels: any;
 


### PR DESCRIPTION
Add support for labeling deprecations.

Upstream: <https://github.com/home-assistant/core/pull/74583>